### PR TITLE
Change ObjectController to ArrayController

### DIFF
--- a/app/scripts/controllers/application_controller.js
+++ b/app/scripts/controllers/application_controller.js
@@ -1,4 +1,4 @@
-RocknrollcallYeoman.ApplicationController = Em.ObjectController.extend({
+RocknrollcallYeoman.ApplicationController = Em.ArrayController.extend({
   searchTerms: '',
   applicationName: function() {
     var st = this.get('searchTerms');


### PR DESCRIPTION
I am reading "Building Web Apps with Ember.js" and found a bug for my project.
I'm running Ubuntu 14.04 LTS with the most recent NVM, NPM, etc.

When running 'grunt serve' the Chrome console would show:
Error: Assertion Failed: The value that #each loops over must be an Array. You passed RocknrollcallYeoman.ApplicationController, but it should have been an ArrayController

I traced it to [/app/scripts/controllers/application_controllers.js]

After testing the fix, deleted and started over (pulling from my fixed branch) and it worked perfectly.

-Allen May
